### PR TITLE
Library build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ fonts/
 images/
 js/
 vendor/
+tmp/
 .sass-cache/

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -81,3 +81,9 @@ require('./tasks/copy')(gulp);
 // Library Tasks
 //////////////////////////////
 require('./tasks/library')(gulp);
+
+
+//////////////////////////////
+// Page Build Tasks
+//////////////////////////////
+require('./tasks/page-build')(gulp);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -76,3 +76,8 @@ require('./tasks/refresh')(gulp);
 // Copy Tasks
 //////////////////////////////
 require('./tasks/copy')(gulp);
+
+//////////////////////////////
+// Library Tasks
+//////////////////////////////
+require('./tasks/library')(gulp);

--- a/helpers/build-menu.js
+++ b/helpers/build-menu.js
@@ -70,7 +70,9 @@ var buildMenuJSON = function (directory, extensions, all, cb) {
 
 
         // if (pattern.group === '') {
+        if (folderHolder[pattern.section] && folderHolder[pattern.section].submenu) {
           folderHolder[pattern.section].submenu.push(item);
+        }
         // }
         // else {
         //   folderHolder[pattern.section + '-' + pattern.group].submenu.push(item);

--- a/helpers/build-menu.js
+++ b/helpers/build-menu.js
@@ -1,0 +1,193 @@
+'use strict';
+
+var walker = require('fs-walk-glob-rules'),
+    parse = require('./parse'),
+    patterns = require('./patterns'),
+    sortBy = require('./sortby');
+
+//////////////////////////////
+// Build the Menu
+//////////////////////////////
+var buildMenuJSON = function (directory, extensions, all, cb) {
+  var start = process.hrtime(),
+      sections = loadSections(),
+      folderHolder = {},
+      folderReverse = {},
+      folderSort = {},
+      output = [];
+
+  // Get the files and folders
+  parse.folders(directory, function (folders) {
+
+    // Builds basic folder information
+    folders.forEach(function (v) {
+
+      var pattern = patterns.info(v);
+      var id = pattern.id;
+      var group = pattern.group;
+      if (pattern.section !== pattern.id) {
+        id = pattern.section + '-' + pattern.id
+        group = pattern.section;
+        if (pattern.group !== '') {
+          group +=  '-' + pattern.group;
+        }
+      }
+
+      folderHolder[id] = {
+        title: pattern.title,
+        group: group,
+        submenu: [],
+        all: []
+      };
+
+      // console.log(pattern);
+
+      if (pattern.section === pattern.id) {
+        folderHolder[id].all.push({
+          title: 'View All',
+          href: '/' + pattern.id
+        });
+      }
+      // // If we're in a subsection, make sure it's prefixed
+      // else {
+      //   folderHolder[id].all.push({
+      //     title: 'View All',
+      //     href: '#/' + pattern.section + '?group=' + pattern.id
+      //   });
+      // }
+    });
+
+
+    parse.files(directory, extensions, function (files) {
+
+      // Sorts files into their groups
+      files.forEach(function (v) {
+        var pattern = patterns.info(v);
+        var item = {
+          title: pattern.title,
+          href: '/' + pattern.section + '/' + pattern.id
+        }
+
+
+        // if (pattern.group === '') {
+          folderHolder[pattern.section].submenu.push(item);
+        // }
+        // else {
+        //   folderHolder[pattern.section + '-' + pattern.group].submenu.push(item);
+        // }
+      });
+
+
+      // console.log(folderHolder);
+      // Grab the core groups
+      for (var k in folderHolder) {
+        var folder = folderHolder[k];
+        var group = folder.group;
+
+        if (folder.group === '') {
+          if (sections[k] && sections[k].title) {
+            folder.title = sections[k].title;
+          }
+          else {
+            folder.title = patterns.titleize(k);
+          }
+          // console.log(folder.title);
+          folderSort[k] = folder;
+          delete folderHolder[k];
+        }
+      }
+      // Reverse the remaining
+      var reverseKeys = Object.keys(folderHolder).reverse();
+      reverseKeys.forEach(function (v) {
+        folderReverse[v] = folderHolder[v];
+      });
+
+      // Deep Nested Items
+      for (var k in folderReverse) {
+        var folder = folderReverse[k];
+        var group = folder.group;
+
+        if (folderReverse[group]) {
+          var subMenu = folder.submenu.sort(function (a, b) {
+                return sortBy.title(a, b);
+              });
+          if (all) {
+            subMenu = subMenu.concat(folder.all);
+          };
+          folderReverse[group].submenu.push({
+            title: folder.title,
+            submenu: subMenu
+          });
+          delete folderReverse[k];
+        }
+      }
+
+      // First Level Items (below core folders)
+      for (var k in folderReverse) {
+        var folder = folderReverse[k];
+        var group = folder.group;
+
+        if (folderSort[group]) {
+          var subMenu = folder.submenu.sort(function (a, b) {
+                return sortBy.title(a, b);
+              });
+          if (all) {
+            subMenu = subMenu.concat(folder.all);
+          };
+          folderSort[group].submenu.push({
+            title: folder.title,
+            submenu: subMenu
+          });
+        }
+      }
+
+      // Core folders
+      for (var k in folderSort) {
+        var folder = folderSort[k];
+        var subMenu = folder.submenu.sort(function (a, b) {
+              return sortBy.title(a, b);
+            });
+        if (all) {
+          subMenu = subMenu.concat(folder.all);
+        };
+
+        if (folder.submenu.length) {
+          output.push({
+            title: folder.title,
+            submenu: subMenu
+          });
+        }
+      }
+
+      // time.elapsed(start, 'build.menuJSON');
+      return cb(output);
+    });
+  });
+}
+
+var loadSections = function loadSections () {
+  var sections = [];
+  var walked = walker.transformSync({
+    root: process.cwd() + '/tmp/',
+    rules: {
+      '**/*.html': '$1'
+    }
+  });
+
+  walked.forEach(function (file) {
+    var path = file.relative.split('/'),
+        pFinal = '',
+        pHolder = '';
+    path.pop();
+    path.shift();
+    pFinal = path.join('/');
+
+    if (pHolder !== '' && sections.indexOf(pHolder) === -1) {
+      sections.push(pHolder);
+    }
+  });
+
+  return sections;
+}
+
+module.exports = buildMenuJSON;

--- a/helpers/library-build.js
+++ b/helpers/library-build.js
@@ -14,6 +14,7 @@ var through = require('through2'),
     fs = require('fs-extra'),
     marked = require('./markdown'),
     swig = require('./swig'),
+    yaml = require('js-yaml'),
     PluginError = gutil.PluginError,
     PLUGIN_NAME = 'library-build';
 
@@ -35,21 +36,9 @@ module.exports = function (options) {
   });
 
   var templateCompile = function (file) {
-    var content = marked(file.contents.toString()),
-        meta = file.meta,
-        templatePath = 'library/templates/',
-        pageTemplate = meta.pageTemplate ? meta.pageTemplate : templatePath + '_layout.html',
-        render = '',
-        layout;
+    var render = marked(file.contents.toString());
 
-    layout = {
-      'title': meta.title ? ' | ' + meta.title : '',
-      'content': content
-    };
-
-    render = swig.compileFile(pageTemplate)({
-      'layout': layout
-    });
+    render = '---\n' + yaml.safeDump(file.meta) + '---\n' + '<div class="base--STYLED">\n' + render + '</div>';
 
     return new Buffer(render);
   }

--- a/helpers/library-build.js
+++ b/helpers/library-build.js
@@ -1,0 +1,98 @@
+//////////////////////////////
+// library-build
+//  - A Gulp Plugin
+//
+// 'Builds markdown files into HTML'
+//////////////////////////////
+'use strict';
+
+//////////////////////////////
+// Variables
+//////////////////////////////
+var through = require('through2'),
+    gutil = require('gulp-util'),
+    fs = require('fs-extra'),
+    marked = require('./markdown'),
+    swig = require('./swig'),
+    PluginError = gutil.PluginError,
+    PLUGIN_NAME = 'library-build';
+
+//////////////////////////////
+// Export
+//////////////////////////////
+module.exports = function (options) {
+  options = options || {};
+
+  //////////////////////////////
+  // Command line arguments for each option
+  //////////////////////////////
+  process.argv.forEach(function (val, index, array) {
+    if (index >= 3) {
+      switch (val) {
+        case '--fail': options.failOnError = true; break;
+      }
+    }
+  });
+
+  var templateCompile = function (file) {
+    var content = marked(file.contents.toString()),
+        meta = file.meta,
+        templatePath = 'library/templates/',
+        pageTemplate = meta.pageTemplate ? meta.pageTemplate : templatePath + '_layout.html',
+        render = '',
+        layout;
+
+    layout = {
+      'title': meta.title ? ' | ' + meta.title : '',
+      'content': content
+    };
+
+    render = swig.compileFile(pageTemplate)({
+      'layout': layout
+    });
+
+    return new Buffer(render);
+  }
+
+  //////////////////////////////
+  // Through Object
+  //////////////////////////////
+  var compile = through.obj(function (file, encoding, cb) {
+    var paths = {
+      'relative': file.path.replace(process.cwd() + '/', ''),
+      'folder': file.path.replace(process.cwd() + '/', '').split('/').slice(0, -1).join('/'),
+      'inner': file.path.replace(process.cwd() + '/', '').split('/').slice(1, -1).join('/')
+    };
+
+    /////////////////////////////
+    // Default plugin issues
+    //////////////////////////////
+    if (file.isNull()) {
+      return cb();
+    }
+    if (file.isStream()) {
+      this.emit('error', new PluginError(PLUGIN_NAME, 'Streams are not supported!'));
+      return cb();
+    }
+
+    //////////////////////////////
+    // Manipulate Files
+    //////////////////////////////
+    file.contents = templateCompile(file);
+    file.path = paths.folder + '/index.html';
+
+    gutil.log('Page ' + gutil.colors.magenta(paths.relative) + ' compiled');
+
+    //////////////////////////////
+    // Push the file back to the stream!
+    //////////////////////////////
+    this.push(file);
+
+    //////////////////////////////
+    // Callback to tell us we're done
+    //////////////////////////////
+    cb();
+  })
+
+  return compile;
+}

--- a/helpers/page-build.js
+++ b/helpers/page-build.js
@@ -39,6 +39,7 @@ var buildFiles = function buildFiles (nav) {
         templatePath = 'library/templates/',
         pageTemplate = content.attributes.pageTemplate ? content.attributes.pageTemplate : templatePath + '_layout.html',
         layout,
+        title,
         render;
 
     // Build the relative path
@@ -51,7 +52,7 @@ var buildFiles = function buildFiles (nav) {
     content.path = pFinal + '/index.html';
 
     layout = {
-      'title': ' | ' + content.attributes.name,
+      'title': content.attributes.name ? ' | ' + content.attributes.name : '',
       'content': content.body,
       'heading': {
         'navigation': nav

--- a/helpers/page-build.js
+++ b/helpers/page-build.js
@@ -1,0 +1,155 @@
+//////////////////////////////
+// Page Build
+//  - A Gulp Plugin
+//
+// Builds a page out of fragments
+//////////////////////////////
+'use strict';
+
+//////////////////////////////
+// Variables
+//////////////////////////////
+var through = require('through2'),
+    gutil = require('gulp-util'),
+    fs = require('fs-extra'),
+    fm = require('front-matter'),
+    walker = require('fs-walk-glob-rules'),
+    _s = require('underscore.string'),
+    buildMenuJSON = require('./build-menu'),
+    swig = require('./swig'),
+    time = require('microtime'),
+    spacing = '',
+    nav = '';
+
+//////////////////////////////
+// Walk ALL the things!
+//////////////////////////////
+var buildFiles = function buildFiles (nav) {
+  var walked = walker.transformSync({
+    root: process.cwd() + '/tmp/',
+    rules: {
+      '**/*.html': '$1'
+    }
+  });
+
+  walked.forEach(function (file) {
+    // Grab the contents of the file
+    var readFile = fs.readFileSync(file.path, 'utf-8'),
+        content = fm(readFile),
+        templatePath = 'library/templates/',
+        pageTemplate = content.attributes.pageTemplate ? content.attributes.pageTemplate : templatePath + '_layout.html',
+        layout,
+        render;
+
+    // Build the relative path
+    var path = file.relative.split('/'),
+        pFinal = '',
+        pHolder = '';
+    path.pop();
+    path.shift();
+    pFinal = path.join('/');
+    content.path = pFinal + '/index.html';
+
+    layout = {
+      'title': ' | ' + content.attributes.name,
+      'content': content.body,
+      'heading': {
+        'navigation': nav
+      }
+    };
+
+    render = swig.compileFile(pageTemplate)({
+      'layout': layout
+    });
+
+    fs.outputFileSync(process.cwd() + '/www/' + content.path, render);
+  });
+
+  return 'done';
+}
+
+//////////////////////////////
+// Build Nav
+//////////////////////////////
+var buildNav = function buildNav (menu) {
+  // _s.humanize();
+  nav = '<nav library-class="navigation" role="navigation">\n';
+
+  menu.forEach(function (section) {
+    nav += buildMenu([section]);
+  });
+
+  nav += '</nav>';
+  return nav;
+}
+
+var buildMenu = function buildMenu (menu, submenu) {
+  var menuList = '';
+
+  spacing = spacing + '  ';
+
+  submenu = submenu ? 'menu--inner' : 'menu';
+
+  menuList += spacing + '<ul library-class="' + submenu + '">\n';
+  menu.forEach(function (item) {
+    menuList += buildMenuItem(item);
+  });
+  menuList += spacing + '</ul>\n';
+
+  spacing = spacing.substring(0, spacing.length - 2);
+
+  return menuList;
+}
+
+var buildMenuItem = function buildMenuItem (item) {
+  var listItem = '';
+
+  spacing = spacing + '  ';
+
+  listItem += spacing;
+
+  if (!item.skip) {
+    if (item.submenu && item.submenu.length) {
+      listItem += '<li library-class="menu--dropdown">';
+      listItem += '<a href="/' + _s.slugify(item.title) + '" library-class="menu--dropdown-toggle">' + item.title + '</a>\n';
+      listItem += buildMenu(item.submenu, true);
+      listItem += spacing + '</li>\n';
+    }
+    else {
+      if (item.href) {
+        listItem += '<li library-class="menu--item">';
+        listItem += '<a href="' + item.href + '" library-class="menu--link">' + item.title + '</a>';
+        listItem += '</li>\n';
+      }
+    }
+  }
+
+  spacing = spacing.substring(0, spacing.length - 2);
+
+  return listItem;
+}
+
+//////////////////////////////
+// Export
+//////////////////////////////
+module.exports = function (options, cb) {
+  options = options || {};
+
+  var start = time.now();
+
+  buildMenuJSON(process.cwd() + '/tmp', ['.html'], true, function (menu) {
+    menu = buildNav(menu);
+
+    var files = buildFiles(menu);
+
+    var end = time.now(),
+        total = Math.round((end - start) / 1000);
+
+    gutil.log('Library rebuilt after ' + gutil.colors.magenta(total + 'ms'));
+    cb();
+  });
+
+  // var found = findStuff();
+  // var menu = buildNav(found.dirs, found.parents);
+  // console.log(menu);
+}

--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var gutil = require('gulp-util'),
+    path = require('path'),
+    dir = require('node-dir');
+
+//////////////////////////////
+// Parses a directory's folders
+//////////////////////////////
+var parseDirectoryFolders = function (directory, cb) {
+  // Create output
+  var output = [];
+
+  dir.subdirs(directory, function (err, subdirs) {
+    // If there's an error, throw an error
+    if (err) {
+      var spError = new gutil.PluginError('Style Prototypes Directory (Folder) Parser', {
+        message: err
+      });
+    }
+    // No error, return the sorted relative paths
+    else {
+      // console.log(subdirs);
+      subdirs.forEach(function (v) {
+        output.push(v.replace(directory, ''));
+      });
+      return cb(output.sort());
+    }
+  });
+}
+
+//////////////////////////////
+// Parses a directory's files
+//////////////////////////////
+var parseDirectoryFiles = function (directory, extensions, cb) {
+  // Create output
+  var output = [];
+  // Parse the directory
+  dir.files(directory, function (err, files) {
+    // If there's an error, throw an error
+    if (err) {
+      var spError = new gutil.PluginError('Style Prototypes Directory (File) Parser', {
+        message: err
+      });
+    }
+    // No error, turn the URLs into relative files
+    else {
+      files.forEach(function (f) {
+        // Push files onto the output tree
+        if (extensions.indexOf(path.extname(f)) >= 0 ) {
+          output.push(f.replace(directory, ''));
+        }
+      });
+    }
+    // Return the callback with the output sorted
+    return cb(output.sort());
+  });
+}
+
+//////////////////////////////
+// Exports
+//////////////////////////////
+module.exports.folders = parseDirectoryFolders;
+module.exports.files = parseDirectoryFiles;

--- a/helpers/pattern-build.js
+++ b/helpers/pattern-build.js
@@ -86,6 +86,10 @@ var templateCompile = function (paths, file, options) {
       'layout': layout
     });
   }
+  else {
+    // console.log(render);
+    render = '---\n' + yaml.safeDump(file.meta) + '---\n' + render;
+  }
 
   return new Buffer(render);
 }

--- a/helpers/pattern-build.js
+++ b/helpers/pattern-build.js
@@ -5,55 +5,13 @@
 //////////////////////////////
 var through = require('through2'),
     gutil = require('gulp-util'),
-    swig = require('swig'),
-    swigInclude = require('swig/lib/tags/include').compile,
+    swig = require('./swig'),
     yaml = require('js-yaml'),
     path = require('path'),
     fs = require('fs-extra'),
     marked = require('./markdown'),
     PluginError = gutil.PluginError,
     PLUGIN_NAME = 'pattern-build';
-
-//////////////////////////////
-// Pattern Swig Tag
-//////////////////////////////
-var swigPatternTag = {
-  parse: function (str, line, parser, types, options) {
-    // Start of a parse
-    parser.on('start', function () {
-
-    });
-
-    // Match of any token
-    parser.on('*', function (token) {
-      if (token.type !== 0 && token.match !== 'from') {
-        this.out.push(token.match)
-      }
-    });
-
-    // End of parse
-    parser.on('end', function () {
-      this.out.push(options.filename || null);
-    });
-
-    // Parser is good to go
-    return true;
-  },
-  compile: function (compiler, args) {
-    var file = '"patterns/' + args[1] + '/' + args[0] + '/' + args[0] + '.html"',
-        pattern = 'pattern ' + args[0] + ' from ' + args[1];
-
-    return '_output += "\\n<!-- {% ' + pattern + ' %} -->\\n" + _swig.compileFile(' + file + ')(_ctx) + "<!-- {% end ' + pattern + ' %} -->\\n";\n';
-  },
-  ends: false
-}
-
-swig.setTag(
-  'pattern',
-  swigPatternTag.parse,
-  swigPatternTag.compile,
-  swigPatternTag.ends
-);
 
 //////////////////////////////
 // Compiling

--- a/helpers/patterns.js
+++ b/helpers/patterns.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var _s = require('underscore.string'),
+    path = require('path');
+
+//////////////////////////////
+// Titleize File Name
+//////////////////////////////
+var titleizeFile = function (name) {
+  return _s.titleize(name.replace(/\b-\b/g, ' ').replace(/--/g, ' - ').replace(/__/g, ' - '));
+}
+
+//////////////////////////////
+// Build Pattern Information
+//////////////////////////////
+var buildPatternInfo = function (file) {
+  if (file.charAt(0) === '/') {
+    file = file.substr(1);
+  }
+
+  var ext = path.extname(file);
+  // Do the initial split
+  var position = process.cwd();
+  if (position.charAt(0) === '/' && file.charAt(0) !== '/') {
+    position = position.substr(1);
+  }
+
+  var split = file.replace(position + '/', '').split('/');
+  // Section will be first item
+  var section = split[0];
+  // Group is path minus filename
+  var group = split.slice(1, split.length - 1).join('-');
+  // Name is filename without extension
+  var name = split[split.length - 1].replace(ext, '');
+  // Title is cleaned up, titelized name
+  var title = titleizeFile(name);
+  // ID is group plus name for files, full name for folders
+  var id = name;
+
+  var pattern = {
+    "section": section,
+    "name": name,
+    "title": title,
+    "id": id,
+    "path": 'partials/' + file,
+    "group": group
+  }
+  return pattern;
+}
+
+//////////////////////////////
+// Exports
+//////////////////////////////
+module.exports.titleize = titleizeFile;
+module.exports.info = buildPatternInfo;

--- a/helpers/sortby.js
+++ b/helpers/sortby.js
@@ -1,0 +1,41 @@
+'use strict';
+
+//////////////////////////////
+// Array sort function for items with properties.
+// Sorts on item[prop]
+//////////////////////////////
+var sortBy = function (a, b, prop) {
+  var propA = a[prop],
+      propB = b[prop];
+
+  if (propA < propB) {
+    return -1;
+  }
+  else if (propA > propB) {
+    return 1;
+  }
+  else {
+    return 0;
+  }
+}
+
+//////////////////////////////
+// Sorts on item.name
+//////////////////////////////
+var byName = function (a, b) {
+  return sortBy(a, b, 'name');
+}
+
+//////////////////////////////
+// Sorts on item.title
+//////////////////////////////
+var byTitle = function (a, b) {
+  return sortBy(a, b, 'title');
+}
+
+//////////////////////////////
+// Exports
+//////////////////////////////
+module.exports.property = sortBy;
+module.exports.name = byName;
+module.exports.title = byTitle;

--- a/helpers/swig.js
+++ b/helpers/swig.js
@@ -1,0 +1,52 @@
+'use strict';
+
+//////////////////////////////
+// Variables
+//////////////////////////////
+var swig = require('swig');
+
+//////////////////////////////
+// Pattern Swig Tag
+//////////////////////////////
+var swigPatternTag = {
+  parse: function (str, line, parser, types, options) {
+    // Start of a parse
+    parser.on('start', function () {
+
+    });
+
+    // Match of any token
+    parser.on('*', function (token) {
+      if (token.type !== 0 && token.match !== 'from') {
+        this.out.push(token.match)
+      }
+    });
+
+    // End of parse
+    parser.on('end', function () {
+      this.out.push(options.filename || null);
+    });
+
+    // Parser is good to go
+    return true;
+  },
+  compile: function (compiler, args) {
+    var file = '"patterns/' + args[1] + '/' + args[0] + '/' + args[0] + '.html"',
+        pattern = 'pattern ' + args[0] + ' from ' + args[1];
+
+    return '_output += "\\n<!-- {% ' + pattern + ' %} -->\\n" + _swig.compileFile(' + file + ')(_ctx) + "<!-- {% end ' + pattern + ' %} -->\\n";\n';
+  },
+  ends: false
+}
+
+swig.setTag(
+  'pattern',
+  swigPatternTag.parse,
+  swigPatternTag.compile,
+  swigPatternTag.ends
+);
+
+//////////////////////////////
+// Export Swig
+//////////////////////////////
+module.exports = swig;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "URIjs": "^1.14.1",
     "eslint": "^0.9.2",
     "fs-extra": "^0.12.0",
+    "gulp-front-matter": "^1.2.1",
     "gulp-if-else": "^1.0.2",
     "gulp-plumber": "^0.6.6",
     "gulp-util": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,17 +28,23 @@
   "devDependencies": {
     "URIjs": "^1.14.1",
     "eslint": "^0.9.2",
+    "front-matter": "^1.0.0",
     "fs-extra": "^0.12.0",
+    "fs-walk-glob-rules": "^0.1.0",
     "gulp-front-matter": "^1.2.1",
     "gulp-if-else": "^1.0.2",
     "gulp-plumber": "^0.6.6",
     "gulp-util": "^3.0.1",
     "js-yaml": "^3.2.3",
     "marked": "^0.3.2",
-    "path": "^0.4.9",
+    "microtime": "^1.2.0",
+    "node-dir": "^0.1.6",
+    "path": "^0.11.14",
     "run-sequence": "^1.0.1",
     "swig": "^1.4.2",
     "through2": "^0.6.3",
-    "uglify-js": "^2.4.15"
+    "uglify-js": "^2.4.15",
+    "underscore.string": "^3.0.3",
+    "walk": "^2.3.9"
   }
 }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -23,7 +23,7 @@ module.exports = function (gulp) {
       ['sass', 'swig'],
 
       // Post-Compiled Files
-      ['css'],
+      ['css', 'page-build'],
 
       // Sequence Callback
       cb
@@ -42,7 +42,7 @@ module.exports = function (gulp) {
       ['sass:server', 'swig:server'],
 
       // Post-Compiled Files
-      ['css'],
+      ['css', 'page-build'],
 
       // Sequence Callback
       cb

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -20,7 +20,7 @@ module.exports = function (gulp) {
       'lint',
 
       // Pre-Compiled Files
-      ['sass', 'swig'],
+      ['sass', 'swig', 'library'],
 
       // Post-Compiled Files
       ['css', 'page-build'],
@@ -39,7 +39,7 @@ module.exports = function (gulp) {
       'lint:server',
 
       // Pre-Compiled Files
-      ['sass:server', 'swig:server'],
+      ['sass:server', 'swig:server', 'library'],
 
       // Post-Compiled Files
       ['css', 'page-build'],

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -16,7 +16,8 @@ module.exports = function (gulp) {
   gulp.task('clean:server', function (cb) {
     return clean([
       'www/**/*',
-      '!www/.gitkeep'
+      '!www/.gitkeep',
+      'tmp/'
     ], cb);
   });
 }

--- a/tasks/library.js
+++ b/tasks/library.js
@@ -31,7 +31,7 @@ module.exports = function (gulp, LibraryPaths) {
   var LibraryTask = function (path) {
     return gulp.src(LibraryPaths)
       .pipe(front({ property: 'meta' }))
-      // .pipe(swig())
+      .pipe(swig())
       .pipe(dest('./tmp/'));
       // .pipe(reload({stream: true}));
   }

--- a/tasks/library.js
+++ b/tasks/library.js
@@ -31,9 +31,9 @@ module.exports = function (gulp, LibraryPaths) {
   var LibraryTask = function (path) {
     return gulp.src(LibraryPaths)
       .pipe(front({ property: 'meta' }))
-      .pipe(swig())
-      .pipe(dest('./www/'))
-      .pipe(reload({stream: true}));
+      // .pipe(swig())
+      .pipe(dest('./tmp/'));
+      // .pipe(reload({stream: true}));
   }
 
   //////////////////////////////

--- a/tasks/library.js
+++ b/tasks/library.js
@@ -1,0 +1,65 @@
+'use strict';
+
+//////////////////////////////
+// Requires
+//////////////////////////////
+var gutil = require('gulp-util'),
+    browserSync = require('browser-sync'),
+    front = require('gulp-front-matter'),
+    swig = require('../helpers/library-build'),
+    dest = require('../helpers/relative-dest'),
+    reload = browserSync.reload;
+
+//////////////////////////////
+// Internal Vars
+//////////////////////////////
+var toLibrary = [
+  'library/**/*.md',
+  '!library/bower_components/**/*'
+];
+
+//////////////////////////////
+// Export
+//////////////////////////////
+module.exports = function (gulp, LibraryPaths) {
+  // Set value of paths to either the default or user entered
+  LibraryPaths = LibraryPaths || toLibrary;
+
+  //////////////////////////////
+  // Encapsulate task in function to choose path to work on
+  //////////////////////////////
+  var LibraryTask = function (path) {
+    return gulp.src(LibraryPaths)
+      .pipe(front({ property: 'meta' }))
+      .pipe(swig())
+      .pipe(dest('./www/'))
+      .pipe(reload({stream: true}));
+  }
+
+  //////////////////////////////
+  // Core Task
+  //////////////////////////////
+  gulp.task('library', function () {
+    return LibraryTask(LibraryPaths);
+  });
+
+  //////////////////////////////
+  // Watch Task
+  //////////////////////////////
+  gulp.task('library:watch', function () {
+    return gulp.watch(LibraryPaths)
+      .on('change', function (event) {
+        // Add absolute and relative (to Gulpfile) paths
+        event.path = {
+          absolute: event.path,
+          relative: event.path.replace(__dirname.replace('/tasks', '') + '/', '')
+        }
+
+        // Notify user of the change
+        gutil.log('File ' + gutil.colors.magenta(event.path.relative) + ' was ' + event.type);
+
+        // Call the task
+        return LibraryTask(event.path.absolute);
+      });
+  });
+}

--- a/tasks/page-build.js
+++ b/tasks/page-build.js
@@ -1,0 +1,48 @@
+'use strict';
+
+//////////////////////////////
+// Requires
+//////////////////////////////
+var gutil = require('gulp-util'),
+    front = require('gulp-front-matter'),
+    browserSync = require('browser-sync'),
+    swig = require('../helpers/page-build'),
+    dest = require('../helpers/relative-dest'),
+    reload = browserSync.reload;
+
+//////////////////////////////
+// Internal Vars
+//////////////////////////////
+var toPageBuild = [
+  'tmp/**/*.html'
+];
+
+//////////////////////////////
+// Export
+//////////////////////////////
+module.exports = function (gulp, PageBuildPaths) {
+  // Set value of paths to either the default or user entered
+  PageBuildPaths = PageBuildPaths || toPageBuild;
+
+  //////////////////////////////
+  // Core Task
+  //////////////////////////////
+  gulp.task('page-build', function (cb) {
+    swig({}, function () {
+      browserSync.reload();
+      cb();
+    });
+  });
+
+  //////////////////////////////
+  // Watch Task
+  //////////////////////////////
+  gulp.task('page-build:watch', function () {
+    return gulp.watch(PageBuildPaths)
+      .on('change', function (event) {
+        swig({}, function () {
+          browserSync.reload();
+        });
+      });
+  });
+}

--- a/tasks/swig.js
+++ b/tasks/swig.js
@@ -30,10 +30,10 @@ module.exports = function (gulp, SwigPaths) {
     return gulp.src(path)
       .pipe(swig({
         'template': true,
-        'page': page === undefined ? false : page
+        'page': false
       }))
-      .pipe(dest('./www/'))
-      .pipe(reload({stream: true}));
+      .pipe(dest('./tmp/'));
+      // .pipe(reload({stream: true}));
   }
 
   //////////////////////////////

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -8,5 +8,5 @@ module.exports = function (gulp) {
   //////////////////////////////
   // Core Task
   //////////////////////////////
-  gulp.task('watch', ['lint:watch', 'sass:watch', 'css:watch', 'swig:watch', 'swig:metadata:watch']);
+  gulp.task('watch', ['lint:watch', 'sass:watch', 'css:watch', 'swig:watch', 'swig:metadata:watch', 'library:watch']);
 }

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -8,5 +8,5 @@ module.exports = function (gulp) {
   //////////////////////////////
   // Core Task
   //////////////////////////////
-  gulp.task('watch', ['lint:watch', 'sass:watch', 'css:watch', 'swig:watch', 'swig:metadata:watch', 'library:watch']);
+  gulp.task('watch', ['lint:watch', 'sass:watch', 'css:watch', 'swig:watch', 'swig:metadata:watch', 'library:watch', 'page-build:watch']);
 }


### PR DESCRIPTION
It'll build out the patterns! It'll build out the navigation! Look at all the fun!

Line by line of what this does:
- Changes pattern compilation from full pages into content partials and stores them in a tmp folder (basically, a compiled cache for all patterns) with front matter for pattern.yml metadata
- Compiles markdown files from `library` into the same tmp folder (this will wind up changing once we get final DX stuff, but it'll work for the time being)
- On change to file in tmp folder (or base compile):
  - Builds out listing of folders and files into JSON to describe structure
  - Builds HTML nav based on JSON
  - Reads all files in and removes their front matter from the content
  - Templates out the full page
  - Writes files to www
- Tasks for cleaning tmp and building pages

This takes precedence over #3 as async callbacks are fired appropriately, works with `n` nested folders, builds out a production navigation, and recompiles all files.

Resolves #3 
Resolves IBM-Watson/patterns#100
